### PR TITLE
Fix AABB expandToContain calculation.

### DIFF
--- a/src/core/bounds/qaxisalignedboundingbox.h
+++ b/src/core/bounds/qaxisalignedboundingbox.h
@@ -99,13 +99,14 @@ public:
 
     inline void expandToContain(const QVector3D &pt)
     {
-        QVector<QVector3D> pts = QVector<QVector3D>() << pt;
+        QVector<QVector3D> pts = QVector<QVector3D>() << minPoint() << maxPoint() << pt;
         update(pts);
     }
 
     inline void expandToContain(const QAxisAlignedBoundingBox &other)
     {
-        QVector<QVector3D> pts = QVector<QVector3D>() << other.minPoint() << other.maxPoint();
+        QVector<QVector3D> pts = QVector<QVector3D>() << minPoint() << maxPoint()
+                                                      << other.minPoint() << other.maxPoint();
         update(pts);
     }
 


### PR DESCRIPTION
The expandToContain(...) method did not include the current AABB's min and max in the point list, so rather than merging the two AABBs or points it would overwrite the AABB with what you passed in, rather than actually expanding it.